### PR TITLE
Added Tailwind

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="w-full h-full bg-baseColor m-0 p-0 font-sans">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
@@ -12,451 +12,451 @@
 
     <title>Weather Wizard</title>
   </head>
-  <body>
-    <div id="app">
-      <div class="header-container">
-        <div class="page-info-container">
-          <div class="logo-container">
-            <i class="fa-solid fa-bolt-lightning" id="logo-icon"></i>
+  <body class="w-full h-full bg-baseColor m-0 p-0 font-sans">
+    <div id="app" class="w-full h-full flex flex-col justify-evenly m-0 p-0 overflow-hidden">
+      <div class="header-container flex my-0 mx-8 items-center h-1/10 gap-10">
+        <div class="page-info-container flex flex-row items-center justify-start">
+          <div class="logo-container h-full px-0 py-2 flex items-center">
+            <i class="fa-solid fa-bolt-lightning text-white text-3xl" id="logo-icon"></i>
           </div>
-          <h1 class="page-title">Weather Wizard</h1>
+          <h1 class="page-title text-white text-center text-2xl ml-4 text-nowrap">Weather Wizard</h1>
         </div>
       </div>
-      <div class="content-container">
-        <div class="weather-container">
-          <div class="main-cities-container" id="main-cities-container">
-            <h2 class="section-header">Main Cities</h2>
+      <div class="content-container mx-8 my-0 flex flex-col justify-around">
+        <div class="weather-container w-full h-3/6 text-white">
+          <div class="main-cities-container w-full h-full flex flex-col justify-evenly" id="main-cities-container">
+            <h2 class="section-header p-0 m-0 text-white text-xl">Main Cities</h2>
 
-            <div id="main-cities-nav" class="main-cities-nav">
-              <button class="city-chip">Pretoria</button>
-              <button class="city-chip">Johannesburg</button>
-              <button class="city-chip">Durban</button>
-              <button class="city-chip">Cape Town</button>
+            <div id="main-cities-nav" class="main-cities-nav w-full m-0 align-middle h-fit flex flex-row justify-between overflow-x-scroll gap-2.5 mb-2">
+              <button class="city-chip bg-pillColor outline-none border-none text-center text-nowrap text-sm rounded-3xl w-fit px-3 py-2 text-pill hover: cursor-pointer">Pretoria</button>
+              <button class="city-chip bg-pillColor outline-none border-none text-center text-nowrap text-sm rounded-3xl w-fit px-3 py-2 text-pill hover: cursor-pointer">Johannesburg</button>
+              <button class="city-chip bg-pillColor outline-none border-none text-center text-nowrap text-sm rounded-3xl w-fit px-3 py-2 text-pill hover: cursor-pointer">Durban</button>
+              <button class="city-chip bg-pillColor outline-none border-none text-center text-nowrap text-sm rounded-3xl w-fit px-3 py-2 text-pill hover: cursor-pointer">Cape Town</button>
             </div>
-            <h3 class="section-header">Forecast</h3>
-            <div class="forecast-container" id="cities-forecast">
-              <div id="pretoria-container" class="city-forecast">
-                <div class="daily-forecast-container" id="forecast-day-1">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
+            <h3 class="section-header p-0 m-0 text-white text-xl">Forecast</h3>
+            <div class="forecast-container h-3/5 w-f" id="cities-forecast">
+              <div id="pretoria-container" class="city-forecast w-full h-full flex flex-row justify-between content-center overflow-x-auto">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-1">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
                     <div
-                      class="min-temp-container"
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="min-temp-container"
                     ></div>
                     <div
-                      class="max-temp-container"
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="max-temp-container"
                     ></div>
                   </div>
                 </div>
 
-                <div class="daily-forecast-container" id="forecast-day-2">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0"  id="forecast-day-2">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
                     <div
-                      class="min-temp-container"
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="min-temp-container"
                     ></div>
                     <div
-                      class="max-temp-container"
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="max-temp-container"
                     ></div>
                   </div>
                 </div>
 
-                <div class="daily-forecast-container" id="forecast-day-3">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-3">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
                     <div
-                      class="min-temp-container"
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="min-temp-container"
                     ></div>
                     <div
-                      class="max-temp-container"
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="max-temp-container"
                     ></div>
                   </div>
                 </div>
 
-                <div class="daily-forecast-container" id="forecast-day-4">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0"  id="forecast-day-4">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
                     <div
-                      class="min-temp-container"
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="min-temp-container"
                     ></div>
                     <div
-                      class="max-temp-container"
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="max-temp-container"
                     ></div>
                   </div>
                 </div>
 
-                <div class="daily-forecast-container" id="forecast-day-5">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0"  id="forecast-day-5">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
                     <div
-                      class="min-temp-container"
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="min-temp-container"
                     ></div>
                     <div
-                      class="max-temp-container"
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="max-temp-container"
                     ></div>
                   </div>
                 </div>
 
-                <div class="daily-forecast-container" id="forecast-day-6">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-6">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
                     <div
-                      class="min-temp-container"
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="min-temp-container"
                     ></div>
                     <div
-                      class="max-temp-container"
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="max-temp-container"
                     ></div>
                   </div>
                 </div>
 
-                <div class="daily-forecast-container" id="forecast-day-7">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hiddenfirst: ml-0"  id="forecast-day-7">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
                     <div
-                      class="min-temp-container"
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="min-temp-container"
                     ></div>
                     <div
-                      class="max-temp-container"
-                      id="max-temp-container"
-                    ></div>
-                  </div>
-                </div>
-              </div>
-
-              <div id="johannesburg-container" class="city-forecast">
-                <div class="daily-forecast-container" id="forecast-day-1">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
-                    <div
-                      class="min-temp-container"
-                      id="min-temp-container"
-                    ></div>
-                    <div
-                      class="max-temp-container"
-                      id="max-temp-container"
-                    ></div>
-                  </div>
-                </div>
-
-                <div class="daily-forecast-container" id="forecast-day-2">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
-                    <div
-                      class="min-temp-container"
-                      id="min-temp-container"
-                    ></div>
-                    <div
-                      class="max-temp-container"
-                      id="max-temp-container"
-                    ></div>
-                  </div>
-                </div>
-
-                <div class="daily-forecast-container" id="forecast-day-3">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
-                    <div
-                      class="min-temp-container"
-                      id="min-temp-container"
-                    ></div>
-                    <div
-                      class="max-temp-container"
-                      id="max-temp-container"
-                    ></div>
-                  </div>
-                </div>
-
-                <div class="daily-forecast-container" id="forecast-day-4">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
-                    <div
-                      class="min-temp-container"
-                      id="min-temp-container"
-                    ></div>
-                    <div
-                      class="max-temp-container"
-                      id="max-temp-container"
-                    ></div>
-                  </div>
-                </div>
-
-                <div class="daily-forecast-container" id="forecast-day-5">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
-                    <div
-                      class="min-temp-container"
-                      id="min-temp-container"
-                    ></div>
-                    <div
-                      class="max-temp-container"
-                      id="max-temp-container"
-                    ></div>
-                  </div>
-                </div>
-
-                <div class="daily-forecast-container" id="forecast-day-6">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
-                    <div
-                      class="min-temp-container"
-                      id="min-temp-container"
-                    ></div>
-                    <div
-                      class="max-temp-container"
-                      id="max-temp-container"
-                    ></div>
-                  </div>
-                </div>
-
-                <div class="daily-forecast-container" id="forecast-day-7">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
-                    <div
-                      class="min-temp-container"
-                      id="min-temp-container"
-                    ></div>
-                    <div
-                      class="max-temp-container"
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="max-temp-container"
                     ></div>
                   </div>
                 </div>
               </div>
 
-              <div id="durban-container" class="city-forecast">
-                <div class="daily-forecast-container" id="forecast-day-1">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
+              <div id="johannesburg-container" class="city-forecast w-full h-full flex flex-row justify-between content-center overflow-x-auto">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-1">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
                     <div
-                      class="min-temp-container"
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="min-temp-container"
                     ></div>
                     <div
-                      class="max-temp-container"
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="max-temp-container"
                     ></div>
                   </div>
                 </div>
 
-                <div class="daily-forecast-container" id="forecast-day-2">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-2">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
                     <div
-                      class="min-temp-container"
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="min-temp-container"
                     ></div>
                     <div
-                      class="max-temp-container"
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="max-temp-container"
                     ></div>
                   </div>
                 </div>
 
-                <div class="daily-forecast-container" id="forecast-day-3">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0"  id="forecast-day-3">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
                     <div
-                      class="min-temp-container"
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="min-temp-container"
                     ></div>
                     <div
-                      class="max-temp-container"
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="max-temp-container"
                     ></div>
                   </div>
                 </div>
 
-                <div class="daily-forecast-container" id="forecast-day-4">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-4">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
                     <div
-                      class="min-temp-container"
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="min-temp-container"
                     ></div>
                     <div
-                      class="max-temp-container"
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="max-temp-container"
                     ></div>
                   </div>
                 </div>
 
-                <div class="daily-forecast-container" id="forecast-day-5">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-5">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
                     <div
-                      class="min-temp-container"
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="min-temp-container"
                     ></div>
                     <div
-                      class="max-temp-container"
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="max-temp-container"
                     ></div>
                   </div>
                 </div>
 
-                <div class="daily-forecast-container" id="forecast-day-6">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-6">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
                     <div
-                      class="min-temp-container"
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="min-temp-container"
                     ></div>
                     <div
-                      class="max-temp-container"
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="max-temp-container"
                     ></div>
                   </div>
                 </div>
 
-                <div class="daily-forecast-container" id="forecast-day-7">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-7">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
                     <div
-                      class="min-temp-container"
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="min-temp-container"
                     ></div>
                     <div
-                      class="max-temp-container"
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="max-temp-container"
                     ></div>
                   </div>
                 </div>
               </div>
 
-              <div id="cape-town-container" class="city-forecast">
-                <div class="daily-forecast-container" id="forecast-day-1">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
+              <div id="durban-container" class="city-forecast w-full h-full flex flex-row justify-between content-center overflow-x-auto">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-1">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
                     <div
-                      class="min-temp-container"
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="min-temp-container"
                     ></div>
                     <div
-                      class="max-temp-container"
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="max-temp-container"
                     ></div>
                   </div>
                 </div>
 
-                <div class="daily-forecast-container" id="forecast-day-2">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-2">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
                     <div
-                      class="min-temp-container"
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="min-temp-container"
                     ></div>
                     <div
-                      class="max-temp-container"
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="max-temp-container"
                     ></div>
                   </div>
                 </div>
 
-                <div class="daily-forecast-container" id="forecast-day-3">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-3">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
                     <div
-                      class="min-temp-container"
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="min-temp-container"
                     ></div>
                     <div
-                      class="max-temp-container"
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="max-temp-container"
                     ></div>
                   </div>
                 </div>
 
-                <div class="daily-forecast-container" id="forecast-day-4">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-4">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
                     <div
-                      class="min-temp-container"
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="min-temp-container"
                     ></div>
                     <div
-                      class="max-temp-container"
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="max-temp-container"
                     ></div>
                   </div>
                 </div>
 
-                <div class="daily-forecast-container" id="forecast-day-5">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-5">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
                     <div
-                      class="min-temp-container"
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="min-temp-container"
                     ></div>
                     <div
-                      class="max-temp-container"
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="max-temp-container"
                     ></div>
                   </div>
                 </div>
 
-                <div class="daily-forecast-container" id="forecast-day-6">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-6">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
                     <div
-                      class="min-temp-container"
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="min-temp-container"
                     ></div>
                     <div
-                      class="max-temp-container"
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="max-temp-container"
                     ></div>
                   </div>
                 </div>
 
-                <div class="daily-forecast-container" id="forecast-day-7">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-7">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
                     <div
-                      class="min-temp-container"
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="min-temp-container"
                     ></div>
                     <div
-                      class="max-temp-container"
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
+                      id="max-temp-container"
+                    ></div>
+                  </div>
+                </div>
+              </div>
+
+              <div id="cape-town-container" class="city-forecast w-full h-full flex flex-row justify-between content-center overflow-x-auto">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-1">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
+                    <div
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
+                      id="min-temp-container"
+                    ></div>
+                    <div
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
+                      id="max-temp-container"
+                    ></div>
+                  </div>
+                </div>
+
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-2">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
+                    <div
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
+                      id="min-temp-container"
+                    ></div>
+                    <div
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
+                      id="max-temp-container"
+                    ></div>
+                  </div>
+                </div>
+
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-3">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
+                    <div
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
+                      id="min-temp-container"
+                    ></div>
+                    <div
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
+                      id="max-temp-container"
+                    ></div>
+                  </div>
+                </div>
+
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-4">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
+                    <div
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
+                      id="min-temp-container"
+                    ></div>
+                    <div
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
+                      id="max-temp-container"
+                    ></div>
+                  </div>
+                </div>
+
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-5">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
+                    <div
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
+                      id="min-temp-container"
+                    ></div>
+                    <div
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
+                      id="max-temp-container"
+                    ></div>
+                  </div>
+                </div>
+
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-6">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
+                    <div
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
+                      id="min-temp-container"
+                    ></div>
+                    <div
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
+                      id="max-temp-container"
+                    ></div>
+                  </div>
+                </div>
+
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-7">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
+                    <div
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
+                      id="min-temp-container"
+                    ></div>
+                    <div
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="max-temp-container"
                     ></div>
                   </div>
@@ -465,119 +465,119 @@
             </div>
           </div>
 
-          <div class="popup-container" id="popup-container">
-            <div class="popup-loading-container" id="popup-loading-container">
-              <div class="loading-icon">&#129668;</div>
-              <p id="popup-text">Fetching forecast...</p>
+          <div class="popup-container bg-popupColor px-4 py-4 rounded-md hidden w-full h-full" id="popup-container">
+            <div class="popup-loading-container w-full h-full flex flex-col justify-center items-center" id="popup-loading-container">
+              <div class="loading-icon font-semibold">&#129668;</div>
+              <p id="popup-text" class="text-xl">Fetching forecast...</p>
             </div>
-            <div class="popup-forecast-container" id="popup-forecast-container">
-              <div class="popup-header">
-                <h2 class="section-header">Custom location</h2>
-                <i class="fa-solid fa-circle-xmark" id="close-popup-button"></i>
+            <div class="popup-forecast-container w-full h-full flex flex-col justify-between" id="popup-forecast-container">
+              <div class="popup-header flex w-full flex-row justify-between items-center">
+                <h2 class="section-header p-0 m-0 text-white text-xl font-semibold">Custom location</h2>
+                <i class="fa-solid fa-circle-xmark text-white text-2xl hover: cursor-pointer" id="close-popup-button"></i>
               </div>
 
-              <h4 class="popup-forecast-header">7-day Forecast</h4>
-              <div id="custom-container" class="city-forecast">
-                <div class="daily-forecast-container" id="forecast-day-1">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
+              <h4 class="popup-forecast-header text-lg">7-day Forecast</h4>
+              <div id="custom-container" class="city-forecast w-full h-4/5 flex flex-row justify-between content-cenet overflow-x-auto">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0 bg-popupForecastCardColor rounded text-center overflow-hidden first: ml-0" id="forecast-day-1">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold justify-self-center " id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col gap-1.5 h-full justify-center" id="forecast-temp">
                     <div
-                      class="min-temp-container"
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="min-temp-container"
                     ></div>
                     <div
-                      class="max-temp-container"
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="max-temp-container"
                     ></div>
                   </div>
                 </div>
 
-                <div class="daily-forecast-container" id="forecast-day-2">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0 bg-popupForecastCardColor rounded text-center overflow-hidden first: ml-0" id="forecast-day-2">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold justify-self-center " id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col gap-1.5 h-full justify-center" id="forecast-temp">
                     <div
-                      class="min-temp-container"
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="min-temp-container"
                     ></div>
                     <div
-                      class="max-temp-container"
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="max-temp-container"
                     ></div>
                   </div>
                 </div>
 
-                <div class="daily-forecast-container" id="forecast-day-3">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0 bg-popupForecastCardColor rounded text-center overflow-hidden first: ml-0" id="forecast-day-3">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold justify-self-center " id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col gap-1.5 h-full justify-center" id="forecast-temp">
                     <div
-                      class="min-temp-container"
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="min-temp-container"
                     ></div>
                     <div
-                      class="max-temp-container"
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="max-temp-container"
                     ></div>
                   </div>
                 </div>
 
-                <div class="daily-forecast-container" id="forecast-day-4">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0 bg-popupForecastCardColor rounded text-center overflow-hidden first: ml-0" id="forecast-day-4">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold justify-self-center " id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col gap-1.5 h-full justify-center" id="forecast-temp">
                     <div
-                      class="min-temp-container"
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="min-temp-container"
                     ></div>
                     <div
-                      class="max-temp-container"
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="max-temp-container"
                     ></div>
                   </div>
                 </div>
 
-                <div class="daily-forecast-container" id="forecast-day-5">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0 bg-popupForecastCardColor rounded text-center overflow-hidden first: ml-0" id="forecast-day-5">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold justify-self-center " id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col gap-1.5 h-full justify-center" id="forecast-temp">
                     <div
-                      class="min-temp-container"
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="min-temp-container"
                     ></div>
                     <div
-                      class="max-temp-container"
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="max-temp-container"
                     ></div>
                   </div>
                 </div>
 
-                <div class="daily-forecast-container" id="forecast-day-6">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0 bg-popupForecastCardColor rounded text-center overflow-hidden first: ml-0" id="forecast-day-6">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold justify-self-center " id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col gap-1.5 h-full justify-center" id="forecast-temp">
                     <div
-                      class="min-temp-container"
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="min-temp-container"
                     ></div>
                     <div
-                      class="max-temp-container"
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="max-temp-container"
                     ></div>
                   </div>
                 </div>
 
-                <div class="daily-forecast-container" id="forecast-day-7">
-                  <div class="forecast-item-info" id="forecast-date"></div>
-                  <div class="forecast-item-info" id="forecast-weather"></div>
-                  <div class="forecast-item-info" id="forecast-temp">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0 bg-popupForecastCardColor rounded text-center overflow-hidden first: ml-0" id="forecast-day-7">
+                  <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
+                  <div class="forecast-item-info font-semibold justify-self-center " id="forecast-weather"></div>
+                  <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col gap-1.5 h-full justify-center" id="forecast-temp">
                     <div
-                      class="min-temp-container"
+                      class="min-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="min-temp-container"
                     ></div>
                     <div
-                      class="max-temp-container"
+                      class="max-temp-container m-0 rounded-2xl px-2 py-1.5 h-fit"
                       id="max-temp-container"
                     ></div>
                   </div>
@@ -587,21 +587,21 @@
           </div>
         </div>
 
-        <div class="map-container">
-          <div class="map-header">
-            <h2 class="section-header">Global Map</h2>
-            <div id="reset-map-button" class="reset-map-button">
-              <p>Reset Map</p>
+        <div class="map-container w-full h-1/2 flex flex-col justify-evenly">
+          <div class="map-header flex flex-row w-full items-center justify-between">
+            <h2 class="section-header p-0 m-0 text-white text-xl font-semibold">Global Map</h2>
+            <div id="reset-map-button" class="reset-map-button bg-popupColor outline-none border-none text-center text-nowrap rounded-3xl w-fit px-8 py-2 hover: cursor-pointer">
+              <p class="text-white m-0">Reset Map</p>
             </div>
           </div>
 
-          <div class="map-view-container">
-            <div id="map"></div>
+          <div class="map-view-container w-full h-3/4">
+            <div id="map" class="h-full w-full rounded-md"></div>
           </div>
         </div>
       </div>
 
-      <div class="footer-container"></div>
+      <div class="footer-container h-10"></div>
     </div>
 
     <script type="module" src="/src/main.ts"></script>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
   </head>
   <body class="w-full h-full bg-baseColor m-0 p-0 font-sans">
     <div id="app" class="w-full h-full flex flex-col justify-evenly m-0 p-0 overflow-hidden">
-      <div class="header-container flex my-0 mx-8 items-center h-1/10 gap-10">
+      <div class="header-container flex my-0 mx-8 items-center h-[10%] gap-10">
         <div class="page-info-container flex flex-row items-center justify-start">
           <div class="logo-container h-full px-0 py-2 flex items-center">
             <i class="fa-solid fa-bolt-lightning text-white text-3xl" id="logo-icon"></i>
@@ -28,15 +28,15 @@
             <h2 class="section-header p-0 m-0 text-white text-xl">Main Cities</h2>
 
             <div id="main-cities-nav" class="main-cities-nav w-full m-0 align-middle h-fit flex flex-row justify-between overflow-x-scroll gap-2.5 mb-2">
-              <button class="city-chip bg-pillColor outline-none border-none text-center text-nowrap text-sm rounded-3xl w-fit px-3 py-2 text-pill hover: cursor-pointer">Pretoria</button>
-              <button class="city-chip bg-pillColor outline-none border-none text-center text-nowrap text-sm rounded-3xl w-fit px-3 py-2 text-pill hover: cursor-pointer">Johannesburg</button>
-              <button class="city-chip bg-pillColor outline-none border-none text-center text-nowrap text-sm rounded-3xl w-fit px-3 py-2 text-pill hover: cursor-pointer">Durban</button>
-              <button class="city-chip bg-pillColor outline-none border-none text-center text-nowrap text-sm rounded-3xl w-fit px-3 py-2 text-pill hover: cursor-pointer">Cape Town</button>
+              <button class="city-chip bg-pillColor outline-none border-none text-center text-nowrap text-sm rounded-3xl w-fit px-3 py-2 text-pill hover:cursor-pointer">Pretoria</button>
+              <button class="city-chip bg-pillColor outline-none border-none text-center text-nowrap text-sm rounded-3xl w-fit px-3 py-2 text-pill hover:cursor-pointer">Johannesburg</button>
+              <button class="city-chip bg-pillColor outline-none border-none text-center text-nowrap text-sm rounded-3xl w-fit px-3 py-2 text-pill hover:cursor-pointer">Durban</button>
+              <button class="city-chip bg-pillColor outline-none border-none text-center text-nowrap text-sm rounded-3xl w-fit px-3 py-2 text-pill hover:cursor-pointer">Cape Town</button>
             </div>
             <h3 class="section-header p-0 m-0 text-white text-xl">Forecast</h3>
             <div class="forecast-container h-3/5 w-f" id="cities-forecast">
               <div id="pretoria-container" class="city-forecast w-full h-full flex flex-row justify-between content-center overflow-x-auto">
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-1">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first:ml-0" id="forecast-day-1">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
@@ -51,7 +51,7 @@
                   </div>
                 </div>
 
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0"  id="forecast-day-2">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first:ml-0"  id="forecast-day-2">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
@@ -66,7 +66,7 @@
                   </div>
                 </div>
 
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-3">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first:ml-0" id="forecast-day-3">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
@@ -81,7 +81,7 @@
                   </div>
                 </div>
 
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0"  id="forecast-day-4">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first:ml-0"  id="forecast-day-4">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
@@ -96,7 +96,7 @@
                   </div>
                 </div>
 
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0"  id="forecast-day-5">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first:ml-0"  id="forecast-day-5">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
@@ -111,7 +111,7 @@
                   </div>
                 </div>
 
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-6">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first:ml-0" id="forecast-day-6">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
@@ -126,7 +126,7 @@
                   </div>
                 </div>
 
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hiddenfirst: ml-0"  id="forecast-day-7">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first:ml-0"  id="forecast-day-7">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
@@ -143,7 +143,7 @@
               </div>
 
               <div id="johannesburg-container" class="city-forecast w-full h-full flex flex-row justify-between content-center overflow-x-auto">
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-1">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first:ml-0" id="forecast-day-1">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
@@ -158,7 +158,7 @@
                   </div>
                 </div>
 
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-2">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first:ml-0" id="forecast-day-2">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
@@ -173,7 +173,7 @@
                   </div>
                 </div>
 
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0"  id="forecast-day-3">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first:ml-0"  id="forecast-day-3">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
@@ -188,7 +188,7 @@
                   </div>
                 </div>
 
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-4">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first:ml-0" id="forecast-day-4">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
@@ -203,7 +203,7 @@
                   </div>
                 </div>
 
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-5">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first:ml-0" id="forecast-day-5">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
@@ -218,7 +218,7 @@
                   </div>
                 </div>
 
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-6">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first:ml-0" id="forecast-day-6">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
@@ -233,7 +233,7 @@
                   </div>
                 </div>
 
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-7">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first:ml-0" id="forecast-day-7">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
@@ -250,7 +250,7 @@
               </div>
 
               <div id="durban-container" class="city-forecast w-full h-full flex flex-row justify-between content-center overflow-x-auto">
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-1">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first:ml-0" id="forecast-day-1">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
@@ -265,7 +265,7 @@
                   </div>
                 </div>
 
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-2">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first:ml-0" id="forecast-day-2">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
@@ -280,7 +280,7 @@
                   </div>
                 </div>
 
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-3">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first:ml-0" id="forecast-day-3">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
@@ -295,7 +295,7 @@
                   </div>
                 </div>
 
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-4">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first:ml-0" id="forecast-day-4">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
@@ -310,7 +310,7 @@
                   </div>
                 </div>
 
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-5">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first:ml-0" id="forecast-day-5">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
@@ -325,7 +325,7 @@
                   </div>
                 </div>
 
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-6">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first:ml-0" id="forecast-day-6">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
@@ -340,7 +340,7 @@
                   </div>
                 </div>
 
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-7">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first:ml-0" id="forecast-day-7">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
@@ -357,7 +357,7 @@
               </div>
 
               <div id="cape-town-container" class="city-forecast w-full h-full flex flex-row justify-between content-center overflow-x-auto">
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-1">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first:ml-0" id="forecast-day-1">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
@@ -372,7 +372,7 @@
                   </div>
                 </div>
 
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-2">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first:ml-0" id="forecast-day-2">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
@@ -387,7 +387,7 @@
                   </div>
                 </div>
 
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-3">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first:ml-0" id="forecast-day-3">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
@@ -402,7 +402,7 @@
                   </div>
                 </div>
 
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-4">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first:ml-0" id="forecast-day-4">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
@@ -417,7 +417,7 @@
                   </div>
                 </div>
 
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-5">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first:ml-0" id="forecast-day-5">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
@@ -432,7 +432,7 @@
                   </div>
                 </div>
 
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-6">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first:ml-0" id="forecast-day-6">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
@@ -447,7 +447,7 @@
                   </div>
                 </div>
 
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first: ml-0" id="forecast-day-7">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0  bg-forecastColor rounded-md text-center overflow-hidden first:ml-0" id="forecast-day-7">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold text-6xl justify-self-center self-center" id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col justify-center gap-1.5 h-full" id="forecast-temp">
@@ -473,12 +473,12 @@
             <div class="popup-forecast-container w-full h-full flex flex-col justify-between" id="popup-forecast-container">
               <div class="popup-header flex w-full flex-row justify-between items-center">
                 <h2 class="section-header p-0 m-0 text-white text-xl font-semibold">Custom location</h2>
-                <i class="fa-solid fa-circle-xmark text-white text-2xl hover: cursor-pointer" id="close-popup-button"></i>
+                <i class="fa-solid fa-circle-xmark text-white text-2xl hover:cursor-pointer" id="close-popup-button"></i>
               </div>
 
               <h4 class="popup-forecast-header text-lg">7-day Forecast</h4>
               <div id="custom-container" class="city-forecast w-full h-4/5 flex flex-row justify-between content-cenet overflow-x-auto">
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0 bg-popupForecastCardColor rounded text-center overflow-hidden first: ml-0" id="forecast-day-1">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0 bg-popupForecastCardColor rounded text-center overflow-hidden first:ml-0" id="forecast-day-1">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold justify-self-center " id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col gap-1.5 h-full justify-center" id="forecast-temp">
@@ -493,7 +493,7 @@
                   </div>
                 </div>
 
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0 bg-popupForecastCardColor rounded text-center overflow-hidden first: ml-0" id="forecast-day-2">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0 bg-popupForecastCardColor rounded text-center overflow-hidden first:ml-0" id="forecast-day-2">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold justify-self-center " id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col gap-1.5 h-full justify-center" id="forecast-temp">
@@ -508,7 +508,7 @@
                   </div>
                 </div>
 
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0 bg-popupForecastCardColor rounded text-center overflow-hidden first: ml-0" id="forecast-day-3">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0 bg-popupForecastCardColor rounded text-center overflow-hidden first:ml-0" id="forecast-day-3">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold justify-self-center " id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col gap-1.5 h-full justify-center" id="forecast-temp">
@@ -523,7 +523,7 @@
                   </div>
                 </div>
 
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0 bg-popupForecastCardColor rounded text-center overflow-hidden first: ml-0" id="forecast-day-4">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0 bg-popupForecastCardColor rounded text-center overflow-hidden first:ml-0" id="forecast-day-4">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold justify-self-center " id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col gap-1.5 h-full justify-center" id="forecast-temp">
@@ -538,7 +538,7 @@
                   </div>
                 </div>
 
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0 bg-popupForecastCardColor rounded text-center overflow-hidden first: ml-0" id="forecast-day-5">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0 bg-popupForecastCardColor rounded text-center overflow-hidden first:ml-0" id="forecast-day-5">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold justify-self-center " id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col gap-1.5 h-full justify-center" id="forecast-temp">
@@ -553,7 +553,7 @@
                   </div>
                 </div>
 
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0 bg-popupForecastCardColor rounded text-center overflow-hidden first: ml-0" id="forecast-day-6">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0 bg-popupForecastCardColor rounded text-center overflow-hidden first:ml-0" id="forecast-day-6">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold justify-self-center " id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col gap-1.5 h-full justify-center" id="forecast-temp">
@@ -568,7 +568,7 @@
                   </div>
                 </div>
 
-                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0 bg-popupForecastCardColor rounded text-center overflow-hidden first: ml-0" id="forecast-day-7">
+                <div class="daily-forecast-container h-full grid justify-evenly items-center mx-2 my-0 bg-popupForecastCardColor rounded text-center overflow-hidden first:ml-0" id="forecast-day-7">
                   <div class="forecast-item-info text-white text-xl m-0 p-0" id="forecast-date"></div>
                   <div class="forecast-item-info font-semibold justify-self-center " id="forecast-weather"></div>
                   <div class="forecast-item-info text-white text-base m-0 p-0 flex flex-col gap-1.5 h-full justify-center" id="forecast-temp">
@@ -590,7 +590,7 @@
         <div class="map-container w-full h-1/2 flex flex-col justify-evenly">
           <div class="map-header flex flex-row w-full items-center justify-between">
             <h2 class="section-header p-0 m-0 text-white text-xl font-semibold">Global Map</h2>
-            <div id="reset-map-button" class="reset-map-button bg-popupColor outline-none border-none text-center text-nowrap rounded-3xl w-fit px-8 py-2 hover: cursor-pointer">
+            <div id="reset-map-button" class="reset-map-button bg-popupColor outline-none border-none text-center text-nowrap rounded-3xl w-fit px-8 py-2 hover:cursor-pointer">
               <p class="text-white m-0">Reset Map</p>
             </div>
           </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,11 +14,14 @@
       },
       "devDependencies": {
         "@types/leaflet": "^1.9.8",
+        "autoprefixer": "^10.4.18",
         "eslint": "^8.56.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-plugin-import": "^2.29.1",
+        "postcss": "^8.4.35",
         "prettier": "3.2.5",
         "sass": "^1.71.0",
+        "tailwindcss": "^3.4.1",
         "typescript": "^5.3.3",
         "vite": "^5.1.0"
       }
@@ -30,6 +33,18 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -489,6 +504,98 @@
       "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
       "dev": true
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.24",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.24.tgz",
+      "integrity": "sha512-+VaWXDa6+l6MhflBvVXjIEAzb59nQ2JUK3bwRp2zRpPtU+8TFRy9Gg/5oIcNlkEL5PGlBFGfemUVvIgLnTzq7Q==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -522,6 +629,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -787,6 +904,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -799,6 +922,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -937,6 +1066,43 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/autoprefixer": {
+      "version": "10.4.18",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.18.tgz",
+      "integrity": "sha512-1DKbDfsr6KUElM6wg+0zRNkB/Q7WcKYAaK+pzXn+Xqmszm/5Xa9coeNdtP88Vi+dPzZnMjhge8GIV49ZQkDa+g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "browserslist": "^4.23.0",
+        "caniuse-lite": "^1.0.30001591",
+        "fraction.js": "^4.3.7",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.0.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -989,6 +1155,38 @@
         "node": ">=8"
       }
     },
+    "node_modules/browserslist": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
+      "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001587",
+        "electron-to-chromium": "^1.4.668",
+        "node-releases": "^2.0.14",
+        "update-browserslist-db": "^1.0.13"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
@@ -1016,6 +1214,35 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001591",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001591.tgz",
+      "integrity": "sha512-PCzRMei/vXjJyL5mJtzNiUCKP59dm8Apqc3PH8gJkMnMXZGox93RbE76jHsmLwmIo6/3nsYIpJtx0O7u5PqFuQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -1087,6 +1314,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1111,6 +1347,18 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/date-fns": {
@@ -1179,6 +1427,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -1190,6 +1450,24 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.4.690",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.690.tgz",
+      "integrity": "sha512-+2OAGjUx68xElQhydpcbqH50hE8Vs2K6TkAeLhICYfndb67CVH0UsZaijmRUE3rHlIxU1u0jxwhgVe6fK3YANA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
     },
     "node_modules/es-abstract": {
       "version": "1.22.4",
@@ -1349,6 +1627,15 @@
         "@esbuild/win32-arm64": "0.19.12",
         "@esbuild/win32-ia32": "0.19.12",
         "@esbuild/win32-x64": "0.19.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -1628,6 +1915,34 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -1716,6 +2031,35 @@
       "dev": true,
       "dependencies": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/fs.realpath": {
@@ -2145,6 +2489,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -2299,6 +2652,33 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/jackspeak": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
+      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
+      "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
+      "dev": true,
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -2368,6 +2748,21 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -2388,6 +2783,37 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+      "dev": true,
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -2410,11 +2836,31 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
+      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.7",
@@ -2440,6 +2886,12 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/node-releases": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
+      "dev": true
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -2447,6 +2899,33 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -2647,6 +3126,22 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "node_modules/path-scurry": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+      "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^9.1.1 || ^10.0.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -2663,6 +3158,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
+      "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -2701,6 +3214,127 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
+      "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
+      "dev": true,
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
+      "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "lilconfig": "^3.0.0",
+        "yaml": "^2.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "postcss": ">=8.0.9",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "postcss": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-load-config/node_modules/lilconfig": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.1.tgz",
+      "integrity": "sha512-O18pf7nyvHTckunPWCV1XUNXU1piu01y2b7ATJ0ppkUkk8ocqVWBrYjJBCwHDjD/ZWcfyrA0P4gKhzWGi5EINQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.1.tgz",
+      "integrity": "sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==",
+      "dev": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.11"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.15",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.15.tgz",
+      "integrity": "sha512-rEYkQOMUCEMhsKbK66tbEU9QVIxbhN18YiniAwA7XQYTVBqrBy+P2p5JcdqsHgKM2zWylp8d7J6eszocfds5Sw==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -2754,6 +3388,15 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -3031,6 +3674,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
@@ -3038,6 +3693,71 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/string.prototype.trim": {
@@ -3097,6 +3817,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -3116,6 +3849,74 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
+      "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "glob": "^10.3.10",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/sucrase/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/sucrase/node_modules/glob": {
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.3.5",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sucrase/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/supports-color": {
@@ -3142,11 +3943,69 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tailwindcss": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.1.tgz",
+      "integrity": "sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==",
+      "dev": true,
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.5.3",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.0",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.19.1",
+        "lilconfig": "^2.1.0",
+        "micromatch": "^4.0.5",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.0.0",
+        "postcss": "^8.4.23",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.1",
+        "postcss-nested": "^6.0.1",
+        "postcss-selector-parser": "^6.0.11",
+        "resolve": "^1.22.2",
+        "sucrase": "^3.32.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -3159,6 +4018,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
@@ -3295,6 +4160,36 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -3303,6 +4198,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
     },
     "node_modules/vite": {
       "version": "5.1.3",
@@ -3409,11 +4310,117 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "node_modules/yaml": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.0.tgz",
+      "integrity": "sha512-j9iR8g+/t0lArF4V6NE/QCfT+CO7iLqrXAHZbJdo+LfjqP1vR8Fg5bSiaq6Q2lOD1AUEVrEVIgABvBFYojJVYQ==",
+      "dev": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -10,11 +10,14 @@
   },
   "devDependencies": {
     "@types/leaflet": "^1.9.8",
+    "autoprefixer": "^10.4.18",
     "eslint": "^8.56.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.29.1",
+    "postcss": "^8.4.35",
     "prettier": "3.2.5",
     "sass": "^1.71.0",
+    "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3",
     "vite": "^5.1.0"
   },

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/style.scss
+++ b/src/style.scss
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 @mixin mobile-view {
   @media (min-width: 0px) and (max-width: 480px) {
     @content;
@@ -18,117 +22,21 @@
 
 html,
 body {
-  width: 100%;
-  height: 100%;
-  background-color: #000835;
-  padding: 0;
-  margin: 0;
-  font-family: sans-serif;
   scrollbar-width: none;
-}
-
-#app {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  padding: 0;
-  overflow: hidden;
-}
-
-.header-container {
-  display: flex;
-  margin: 0 2rem;
-  gap: 10%;
-  align-items: center;
-  height: 10%;
-  width: calc(100% - 2rem);
-
-  .page-info-container {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: flex-start;
-
-    .logo-container {
-      height: 100%;
-      padding: 0.5rem 0;
-      display: flex;
-      align-items: center;
-      #logo-icon {
-        flex: 0 0 5%;
-        color: #fff;
-        font-size: 30px;
-      }
-    }
-
-    .page-title {
-      color: #fff;
-      text-align: center;
-      font-size: 26px;
-      margin-left: 1rem;
-      text-wrap: nowrap;
-    }
-  }
 }
 
 .content-container {
   height: 85%;
-  margin: 0 2rem;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-around;
-
-  .section-header {
-    padding: 0;
-    margin: 0;
-    color: #fff;
-    font-size: 22px;
-  }
 
   .weather-container {
-    width: 100%;
-    height: 50%;
-    color: white;
-
     .main-cities-container {
-      width: 100%;
-      height: 100%;
-      display: flex;
-      flex-direction: column;
-      justify-content: space-evenly;
-
       .main-cities-nav {
-        width: 100%;
-        margin: 0 auto;
-        height: fit-content;
-        display: flex;
-        flex-direction: row;
-        justify-content: space-between;
-        overflow-x: scroll;
-        gap: 0.6rem;
         scrollbar-width: none;
-        margin-bottom: 0.5rem;
 
         .city-chip {
-          background-color: #6153cc22;
-          outline: none;
-          border: none;
-          text-align: center;
-          text-wrap: nowrap;
-          font-size: 14px;
-          border-radius: 20px;
-          width: fit-content;
-          padding: 0.8rem 1rem;
-          color: #b8b8b8;
-
           &.active {
             background-color: #6153cc;
             color: #fff;
-          }
-
-          &:hover {
-            cursor: pointer;
           }
         }
 
@@ -144,17 +52,7 @@ body {
       }
 
       .forecast-container {
-        height: 60%;
-        width: 100%;
-
         .city-forecast {
-          width: 100%;
-          height: 100%;
-          display: flex;
-          flex-direction: row;
-          justify-content: space-between;
-          align-content: center;
-          overflow-x: auto;
           scrollbar-width: none;
 
           @include web-view {
@@ -162,22 +60,13 @@ body {
           }
 
           .daily-forecast-container {
-            height: 100%;
             flex: 0 0 42%;
-            display: grid;
             grid-template-areas:
               "date"
               "weathertype"
               "temperature";
             grid-template-rows: auto auto auto;
-            justify-content: space-evenly;
             width: 42%;
-            align-items: center;
-            margin: 0 0.5rem;
-            background-color: #6153cc2d;
-            border-radius: 5%;
-            text-align: center;
-            overflow: hidden;
 
             @include tablet-view {
               flex: 0 0 25%;
@@ -189,24 +78,13 @@ body {
               width: 18%;
             }
 
-            &:first-child {
-              margin-left: 0;
-            }
-
             #forecast-date {
               grid-area: date;
-              color: #fff;
-              font-size: 20px;
-              margin: 0;
-              padding: 0;
             }
 
             #forecast-weather {
               grid-area: weathertype;
               font-weight: 600;
-              font-size: 60px;
-              justify-self: center;
-              align-self: center;
 
               @include tablet-view {
                 font-size: 60px;
@@ -214,26 +92,6 @@ body {
 
               @include web-view {
                 font-size: 75px;
-              }
-            }
-
-            #forecast-temp {
-              grid-area: temperature;
-              color: #fff;
-              font-size: 16px;
-              margin: 0;
-              padding: 0;
-              display: flex;
-              flex-direction: column;
-              gap: 10%;
-              height: 100%;
-
-              #min-temp-container,
-              #max-temp-container {
-                margin: 0;
-                border-radius: 15px;
-                padding: 0.3rem 0.4rem;
-                height: fit-content;
               }
             }
           }
@@ -242,64 +100,14 @@ body {
     }
 
     .popup-container {
-      height: calc(100% - 2rem);
-      width: calc(100% - 2rem);
-      background-color: #6153cc;
-      padding: 1rem 1rem;
-      border-radius: 5px;
-      display: none;
-
-      .popup-forecast-header {
-        font-weight: 600;
-        font-size: 18px;
-      }
-
       .popup-loading-container {
-        width: 100%;
-        height: 100%;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-
         .loading-icon {
-          font-weight: 600;
           font-size: 60px;
-        }
-
-        p {
-          font-size: 18px;
         }
       }
 
       .popup-forecast-container {
-        width: 100%;
-        height: 100%;
-        display: flex;
-        flex-direction: column;
-        justify-content: space-between;
-
-        .popup-header {
-          display: flex;
-          width: 100%;
-          flex-direction: row;
-          justify-content: space-between;
-          align-items: center;
-
-          #close-popup-button {
-            font-size: 24px;
-            color: #fff;
-          }
-        }
-
         .city-forecast {
-          width: 100%;
-          height: 80%;
-          display: flex;
-          flex-direction: row;
-          justify-content: space-between;
-          align-content: center;
-          overflow-x: auto;
           scrollbar-width: none;
 
           @include web-view {
@@ -307,22 +115,15 @@ body {
           }
 
           .daily-forecast-container {
-            height: 100%;
             flex: 0 0 38%;
-            display: grid;
+
             grid-template-areas:
               "date"
               "weathertype"
               "temperature";
             grid-template-rows: auto auto auto;
-            justify-content: space-evenly;
+
             width: 38%;
-            align-items: center;
-            margin: 0 0.5rem;
-            background-color: #252866;
-            border-radius: 5%;
-            text-align: center;
-            overflow: hidden;
 
             @include tablet-view {
               flex: 0 0 25%;
@@ -334,23 +135,14 @@ body {
               width: 18%;
             }
 
-            &:first-child {
-              margin-left: 0;
-            }
-
             #forecast-date {
               grid-area: date;
-              color: #fff;
-              font-size: 20px;
-              margin: 0;
-              padding: 0;
             }
 
             #forecast-weather {
               grid-area: weathertype;
-              font-weight: 600;
+
               font-size: 60px;
-              justify-self: center;
 
               @include tablet-view {
                 font-size: 60px;
@@ -363,22 +155,6 @@ body {
 
             #forecast-temp {
               grid-area: temperature;
-              color: #fff;
-              font-size: 16px;
-              margin: 0;
-              padding: 0;
-              display: flex;
-              flex-direction: column;
-              gap: 10%;
-              height: 100%;
-
-              #min-temp-container,
-              #max-temp-container {
-                margin: 0;
-                border-radius: 15px;
-                padding: 0.3rem 0.4rem;
-                height: fit-content;
-              }
             }
           }
         }
@@ -387,53 +163,6 @@ body {
   }
 }
 
-.map-container {
-  width: 100%;
-  height: 50%;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-evenly;
-
-  .map-header {
-    display: flex;
-    flex-direction: row;
-    width: 100%;
-    align-items: center;
-    justify-content: space-between;
-
-    .reset-map-button {
-      background-color: #6153cc;
-      outline: none;
-      border: none;
-      text-align: center;
-      text-wrap: nowrap;
-      border-radius: 20px;
-      width: fit-content;
-      padding: 0.5rem 2rem;
-      p {
-        color: #fff;
-        margin: 0;
-      }
-
-      &:hover {
-        cursor: pointer;
-      }
-    }
-  }
-
-  .map-view-container {
-    width: 100%;
-    height: 75%;
-
-    #map {
-      height: 100%;
-      width: 100%;
-      border-radius: 5px;
-    }
-  }
-}
-
 .footer-container {
-  height: 5%;
   grid-area: footer;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,20 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./index.html", "./*.{js,ts}", "./src/**/*.{js,ts}"],
+  theme: {
+    extend: {},
+    colors: {
+      baseColor: "#000835",
+      pillColor: "#6153cc22",
+      forecastColor: "#6153cc2d",
+      popupColor: "#6153cc",
+      popupForecastCardColor: "#252866",
+    },
+    textColor: {
+      white: "#fff",
+      pill: "#b8b8b8",
+    }
+  },
+  plugins: [],
+}
+


### PR DESCRIPTION
Added Tailwind to the project.

- Converted most of the CSS to tailwind equivalent.
- With regards to the `media queries`, `mixins` and styling related to this in CSS, the screen widths have been precisely 
   calculated to allow the scrollable forecast to be cut-off at all times to indicate scrolling. This is why I have not used the 
   screen sizes catered for with/by Tailwind.
- The styling left in the SCSS file represents styling that is specific to the media queries as explained above, or styling 
   where  I was unable to find suitable conversions.
- I will format everything in a new PR soon.

